### PR TITLE
Change `crystal` to a build dependency

### DIFF
--- a/Formula/ameba.rb
+++ b/Formula/ameba.rb
@@ -13,7 +13,7 @@ class Ameba < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on "crystal"
+  depends_on "crystal" => :build
 
   def install
     ENV["CRFLAGS"] = "--release -Dpreview_mt"


### PR DESCRIPTION
`crystal` is not a runtime dependency. It's only needed to build `ameba`.